### PR TITLE
Fix for phpBB3 support + bonus

### DIFF
--- a/src/main/java/fr/xephi/authme/datasource/MySQLThread.java
+++ b/src/main/java/fr/xephi/authme/datasource/MySQLThread.java
@@ -286,6 +286,11 @@ public class MySQLThread extends Thread implements DataSource {
                     pst.setInt(3, 0);
                     pst.setInt(4, 0);
                     pst.executeUpdate();
+                    // Update username_clean in phpbb_users
+                    pst = con.prepareStatement("UPDATE " + tableName + " SET " + tableName + ".username_clean=? WHERE " + columnName + "=?;");
+                    pst.setString(1, auth.getNickname().toLowerCase());
+                    pst.setString(2, auth.getNickname());
+                    pst.executeUpdate();
                     // Update player group in phpbb_users
                     pst = con.prepareStatement("UPDATE " + tableName + " SET " + tableName + ".group_id=? WHERE " + columnName + "=?;");
                     pst.setInt(1, Settings.getPhpbbGroup);
@@ -302,6 +307,9 @@ public class MySQLThread extends Thread implements DataSource {
                     pst = con.prepareStatement("UPDATE " + tableName + " SET " + tableName + ".user_lastvisit=? WHERE " + columnName + "=?;");
                     pst.setLong(1, time);
                     pst.setString(2, auth.getNickname());
+                    pst.executeUpdate();
+                    // Increment num_users
+                    pst = con.prepareStatement("UPDATE " + Settings.getPhpbbPrefix + "config SET config_value = config_value + 1 WHERE config_name = 'num_users';");
                     pst.executeUpdate();
                 }
             }


### PR DESCRIPTION
username_clean
PhpBB3 requires second column (username_clen) with username as table primary key. Yet, config value "mySQLOtherUsernameColumns" is not an option as this value needs to be formated with phpBB custom utf8_clean_string() function which brings letters to lower case, merges nearby spaces and removes invalid UTF8 chatacters.
Due to characters already being limited both in config and in minecraft itself I believe toLowerCaste() will suffice for now.

num_users
Increment users count not to loose those nice statistics!