### PR TITLE
Cancel damage if unlogged-in player is attacking other entities

### DIFF
--- a/src/main/java/fr/xephi/authme/listener/AuthMeEntityListener.java
+++ b/src/main/java/fr/xephi/authme/listener/AuthMeEntityListener.java
@@ -6,6 +6,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityInteractEvent;
 import org.bukkit.event.entity.EntityRegainHealthEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
@@ -96,6 +97,28 @@ public class AuthMeEntityListener implements Listener {
         event.setTarget(null);
         event.setCancelled(true);
     }
+    
+    @EventHandler(priority = EventPriority.LOWEST)
+	public void onDmg(EntityDamageByEntityEvent event) {
+		if (event.isCancelled()) {
+            return;
+        }
+		
+		Entity entity = event.getDamager();
+		
+		if (entity == null || !(entity instanceof Player)) {
+            return;
+        }
+		
+		Player player = (Player) entity;
+		String name = player.getName();
+		
+        if (PlayerCache.getInstance().isAuthenticated(name)) {
+            return;
+        }
+        
+        event.setCancelled(true);
+	}
 
     @EventHandler (priority = EventPriority.LOWEST)
     public void onFoodLevelChange(FoodLevelChangeEvent event) {


### PR DESCRIPTION
Right now players can hit other players before logging in, causing serious issues with plugins like CombatTag, PvPManager etc.
We should cancel this in a simple EntityDamageByEntity listener.

Did not test the code.