### PR TITLE
Fix NPE when onPlayerJoins occurs

### DIFF
--- a/src/main/java/fr/xephi/authme/cache/limbo/LimboCache.java
+++ b/src/main/java/fr/xephi/authme/cache/limbo/LimboCache.java
@@ -96,7 +96,7 @@ public class LimboCache {
         if (player.isDead()) {
             loc = plugin.getSpawnLocation(player);
         }
-        cache.put(player.getName(), new LimboPlayer(name, loc, inv, arm, gameMode, operator, playerGroup, flying));
+        cache.put(name, new LimboPlayer(name, loc, inv, arm, gameMode, operator, playerGroup, flying));
     }
 
     public void addLimboPlayer(Player player, String group) {


### PR DESCRIPTION
When #addLimboPlayer(Player player) is called, the player is put into the list with his real name, but when #getLimboPlayer(String name) is called, its looking for the lowercased name, causing a NullPointerException