### PR TITLE
Email recall at login, typo fix and ChangePassword Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ AuthMe Reloaded prevents players who aren't logged in from actions like placing 
 </li><li>Possible to use without a Permissions plugin
 </li><li><strong>Spoutcraft Login GUI</strong>
 </li><li>Automatic backup system of all your user password data
-</li><li>Default Language Style: en, de, br, cz, pl, fr, ru, hu, sk, es, zhtw, fi, zhcn, nl ( feel free to send new translations )
+</li><li>Default Language Style: en, de, br, cz, pl, fr, it, ru, hu, sk, es, zhtw, fi, zhcn, nl ( feel free to send new translations )
 </li><li>Convert the FlatFile auths.db to an usefull authme.sql that you can use on a MySQL database !
 </li><li>Import your database from Rakamak, xAuth, CrazyLogin, RoyalAuth, vAuth !
 </li></ul>

--- a/src/main/java/fr/xephi/authme/commands/ChangePasswordCommand.java
+++ b/src/main/java/fr/xephi/authme/commands/ChangePasswordCommand.java
@@ -54,13 +54,19 @@ public class ChangePasswordCommand implements CommandExecutor {
         }
 
         String lowpass = args[1].toLowerCase();
-        if ((lowpass.contains("delete") || lowpass.contains("where") || lowpass.contains("insert") || lowpass.contains("modify") || lowpass.contains("from") || lowpass.contains("select") || lowpass.contains(";") || lowpass.contains("null")) || !lowpass.matches(Settings.getPassRegex)) {
+        if ((lowpass.contains("delete") || lowpass.contains("where") || lowpass.contains("insert") || lowpass.contains("modify") || lowpass.contains("from") || lowpass.contains("select") || lowpass.contains(";") || lowpass.contains("null")) || !lowpass.matches(Settings.getPassRegex) || lowpass.equalsIgnoreCase(name)) {
             m.send(player, "password_error");
             return true;
         }
-        if (lowpass.equalsIgnoreCase(name)) {
-            m.send(player, "password_error");
+        if (lowpass.length() < Settings.getPasswordMinLen || lowpass.length() > Settings.passwordMaxLength) {
+            m.send(player, "pass_len");
             return true;
+        }
+        if (!Settings.unsafePasswords.isEmpty()) {
+            if (Settings.unsafePasswords.contains(lowpass)) {
+                m.send(player, "password_error");
+                return true;
+            }
         }
         try {
             String hashnew = PasswordSecurity.getHash(Settings.getPasswordHash, args[1], name);

--- a/src/main/java/fr/xephi/authme/process/join/AsyncronousJoin.java
+++ b/src/main/java/fr/xephi/authme/process/join/AsyncronousJoin.java
@@ -100,7 +100,7 @@ public class AsyncronousJoin {
                 long timeout = Settings.getSessionTimeout * 60000;
                 long lastLogin = auth.getLastLogin();
                 long cur = new Date().getTime();
-                if ((cur - lastLogin < timeout || timeout == 0) && !auth.getIp().equals("198.18.0.1")) {
+                if ((cur - lastLogin < timeout || timeout == 0) && !auth.getIp().matches("198.168.(0|1).1")) {
                     if (auth.getNickname().equalsIgnoreCase(name) && auth.getIp().equals(ip)) {
                         if (PlayerCache.getInstance().getAuth(name) != null) {
                             PlayerCache.getInstance().updatePlayer(auth);

--- a/src/main/java/fr/xephi/authme/process/login/AsyncronousLogin.java
+++ b/src/main/java/fr/xephi/authme/process/login/AsyncronousLogin.java
@@ -152,8 +152,6 @@ public class AsyncronousLogin {
             displayOtherAccounts(auth, player);
             
             if (Settings.recallEmail) {
-                String name = player.getName().toLowerCase();
-                String email = database.getAuth(name).getEmail();
                 if (email == null || email.isEmpty() || email.equalsIgnoreCase("your@email.com"))
                     m.send(player, "add_email");
             }

--- a/src/main/java/fr/xephi/authme/process/login/AsyncronousLogin.java
+++ b/src/main/java/fr/xephi/authme/process/login/AsyncronousLogin.java
@@ -150,6 +150,14 @@ public class AsyncronousLogin {
             m.send(player, "login");
 
             displayOtherAccounts(auth, player);
+            
+            if (Settings.recallEmail) {
+                String name = player.getName().toLowerCase();
+                String email = database.getAuth(name).getEmail();
+                if (email == null || email.isEmpty() || email.equalsIgnoreCase("your@email.com"))
+                    m.send(player, "add_email");
+            }
+
 
             if (!Settings.noConsoleSpam)
                 ConsoleLogger.info(player.getName() + " logged in!");


### PR DESCRIPTION
More details inside commit descriptions.

Also, I'd like to suggest a new feature:
If someone has an unsafe password, or password=username, or password < minLenght, or password > maxLenght, or password contains "where", "delete", etc, or password doesn't match pass REG_EX, then the player is logged in, but is forced to use /changepassword oldPass newPass to change is password to a safer one in order to play again.