### PR TITLE
Enhanced Password Regex

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -165,7 +165,7 @@ settings:
         # AuthMe will NEVER teleport players !
         noTeleport: false
         # Regex sintax for allowed Chars in passwords.
-        allowedPasswordCharacters: '[a-zA-Z0-9_?!@+&-]*'
+        allowedPasswordCharacters: '[\x21-\x7E]*'
     GameMode:
         # ForceSurvivalMode to player when join ?
         ForceSurvivalMode: false


### PR DESCRIPTION
We are now allowing every ASCII character except for space (0x20 - 32). Those are the characters allowed in passwords.

Note: You may want to check if in config a single slash is OK for excluding a character, or if we need 2 like in the code.