### PR TITLE
Updated PBKDF2 hasher to support Django 1.7+

### DIFF
--- a/src/main/java/fr/xephi/authme/security/crypts/CryptPBKDF2.java
+++ b/src/main/java/fr/xephi/authme/security/crypts/CryptPBKDF2.java
@@ -14,7 +14,7 @@ public class CryptPBKDF2 implements EncryptionMethod {
         String result = "pbkdf2_sha256$15000$" + salt + "$";
         PBKDF2Parameters params = new PBKDF2Parameters("HmacSHA256", "ASCII", salt.getBytes(), 15000);
         PBKDF2Engine engine = new PBKDF2Engine(params);
-        
+
         return result + String.valueOf(DatatypeConverter.printBase64Binary(engine.deriveKey(password, 32)));
     }
 

--- a/src/main/java/fr/xephi/authme/security/crypts/CryptPBKDF2.java
+++ b/src/main/java/fr/xephi/authme/security/crypts/CryptPBKDF2.java
@@ -4,17 +4,18 @@ import java.security.NoSuchAlgorithmException;
 
 import fr.xephi.authme.security.pbkdf2.PBKDF2Engine;
 import fr.xephi.authme.security.pbkdf2.PBKDF2Parameters;
+import javax.xml.bind.DatatypeConverter;
 
 public class CryptPBKDF2 implements EncryptionMethod {
 
     @Override
     public String getHash(String password, String salt, String name)
             throws NoSuchAlgorithmException {
-        String result = "pbkdf2_sha256$10000$" + salt + "$";
-        PBKDF2Parameters params = new PBKDF2Parameters("HmacSHA256", "ASCII", salt.getBytes(), 10000);
+        String result = "pbkdf2_sha256$15000$" + salt + "$";
+        PBKDF2Parameters params = new PBKDF2Parameters("HmacSHA256", "ASCII", salt.getBytes(), 15000);
         PBKDF2Engine engine = new PBKDF2Engine(params);
-
-        return result + String.valueOf(engine.deriveKey(password, 64));
+        
+        return result + String.valueOf(DatatypeConverter.printBase64Binary(engine.deriveKey(password, 32)));
     }
 
     @Override
@@ -22,8 +23,8 @@ public class CryptPBKDF2 implements EncryptionMethod {
             String playerName) throws NoSuchAlgorithmException {
         String[] line = hash.split("\\$");
         String salt = line[2];
-        String derivedKey = line[3];
-        PBKDF2Parameters params = new PBKDF2Parameters("HmacSHA256", "ASCII", salt.getBytes(), 10000, derivedKey.getBytes());
+        byte[] derivedKey = DatatypeConverter.parseBase64Binary(line[3]);
+        PBKDF2Parameters params = new PBKDF2Parameters("HmacSHA256", "ASCII", salt.getBytes(), 15000, derivedKey);
         PBKDF2Engine engine = new PBKDF2Engine(params);
         return engine.verifyKey(password);
     }


### PR DESCRIPTION
Hi guys,

just to fix Django hasher. An old one was generating wrong hashes like "pbkdf2_sha256$10000$8b517484413f$[BT6725e86e". Currently Django 1.7+ is using 15K iterations and 32 length Base64-encoded hashes (pbkdf2_sha256$15000$ffde44201173$AQggmMBg0sGNWbWkO2qJLZTU6AWl11amcV4zNE1Zuts=).

Thanks for the great plugin.