### PR TITLE
Fix duplicate registers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 		<!-- EssentialsX Repo -->
 		<repository>
 			<id>ess-repo</id>
-			<url>https://ci.drtshock.net/plugin/repository/everything</url>
+			<url>http://ci.drtshock.net/plugin/repository/everything</url>
 		</repository>
 
 		<!-- CombatTagPlus Repo -->
@@ -257,7 +257,7 @@
 			</exclusions>
 		</dependency>
 
-		<!-- Spigot-Api, http://www.spigotmc.org/ Based on the Bukkit project, 
+		<!-- Spigot-Api, http://www.spigotmc.org/ Based on the Bukkit project,
 			http://bukkit.org/ -->
 		<dependency>
 			<groupId>org.bukkit</groupId>

--- a/src/main/java/fr/xephi/authme/process/register/AsyncronousRegister.java
+++ b/src/main/java/fr/xephi/authme/process/register/AsyncronousRegister.java
@@ -67,14 +67,10 @@ public class AsyncronousRegister {
             allowRegister = false;
         }
 
-        else if (!Settings.unsafePasswords.isEmpty()) {
-            if (Settings.unsafePasswords.contains(password.toLowerCase())) {
-                m.send(player, "password_error_unsafe");
-                allowRegister = false;
-            }
-        }
-
-        else if (database.isAuthAvailable(name)) {
+        else if (!Settings.unsafePasswords.isEmpty() && Settings.unsafePasswords.contains(password.toLowerCase())) {
+            m.send(player, "password_error_unsafe");
+            allowRegister = false;
+        } else if (database.isAuthAvailable(name)) {
             m.send(player, "user_regged");
             allowRegister = false;
         }


### PR DESCRIPTION
Related issue #223 

If the list of unsafe password in the configuration isn't empty it doesn't check if the account already exists. It just skips the other checks and continue the register process like everything else is checked.

This pr also fixes a invalid repository link where it's impossible to download the dependency from Essentials.