### PR TITLE
Fix for inventory protection

### DIFF
--- a/src/main/java/fr/xephi/authme/AuthMe.java
+++ b/src/main/java/fr/xephi/authme/AuthMe.java
@@ -654,15 +654,16 @@ public class AuthMe extends JavaPlugin {
                 Settings.protectInventoryBeforeLogInEnabled = false;
                 newSettings.setProperty(RestrictionSettings.PROTECT_INVENTORY_BEFORE_LOGIN, false);
             }
+            if (inventoryProtector != null) {
+                inventoryProtector.unregister();
+                inventoryProtector = null;
+            }
             return;
         }
-
+        
         if (newSettings.getProperty(RestrictionSettings.PROTECT_INVENTORY_BEFORE_LOGIN) && inventoryProtector == null) {
             inventoryProtector = new AuthMeInventoryPacketAdapter(this);
             inventoryProtector.register();
-        } else if (inventoryProtector != null) {
-            inventoryProtector.unregister();
-            inventoryProtector = null;
         }
         if (tabComplete == null && newSettings.getProperty(RestrictionSettings.DENY_TABCOMPLETE_BEFORE_LOGIN)) {
             tabComplete = new AuthMeTabCompletePacketAdapter(this);


### PR DESCRIPTION
Inventory protection was not working even if ProtocolLib was enabled.
Basically, it was enabling at onEnable and disabling at PluginEnableEvent.